### PR TITLE
Enhance Knowlegde-XML file reading

### DIFF
--- a/src/tubame.knowhow.biz/src/main/java/tubame/knowhow/biz/util/JaxbUtil.java
+++ b/src/tubame.knowhow.biz/src/main/java/tubame/knowhow/biz/util/JaxbUtil.java
@@ -46,6 +46,7 @@ public final class JaxbUtil {
     /** Logger */
     private static final Logger LOGGER = LoggerFactory
             .getLogger(JaxbUtil.class);
+    private static final Map<String, JAXBContext> contextMap = new HashMap<String, JAXBContext>();
     /** Know-how marshaler */
     private static final Marshaller KNOWHOW_MARSHALLER = getKnowhowMarshaller();
     /** Know-how unmarshaller */
@@ -54,6 +55,22 @@ public final class JaxbUtil {
     private static final Marshaller DOCBOOK_MARSHALLER = getDocbookMarshaller();
     /** DocBook unmarshaller */
     private static final Unmarshaller DOCBOOK_UNMARSHALLER = getDocbookUnmarshaller();
+
+    private static final JAXBContext getInstance(Class<?> clazz) {
+    	JAXBContext instance = null;
+    	LOGGER.info("Get JAXBContext start: " + clazz.getName());
+		try {
+			instance = contextMap.get(clazz.getName());
+			if (instance == null) {
+				instance = JAXBContext.newInstance(clazz.getName());
+				contextMap.put(clazz.getName(), instance);
+			}
+		} catch (JAXBException e) {
+			// nop
+		}
+		LOGGER.info("Get JAXBContext end: " + clazz.getName());
+		return instance;
+	}
 
     /**
      * Constructor.<br/>
@@ -81,7 +98,7 @@ public final class JaxbUtil {
         try {
             LOGGER.trace(MessagePropertiesUtil
                     .getMessage(MessagePropertiesUtil.LOG_START_CREATE_DOCBOOK_UNMARSHALLER));
-            JAXBContext jaxbContext = JAXBContext.newInstance(Article.class);
+            JAXBContext jaxbContext = getInstance(Article.class);
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
             unmarshaller.setSchema(JaxbUtil.getSchema(ApplicationPropertiesUtil
                     .getProperty(ApplicationPropertiesUtil.DOCBOOKSCHEMA_PATH),
@@ -107,7 +124,7 @@ public final class JaxbUtil {
         try {
             LOGGER.trace(MessagePropertiesUtil
                     .getMessage(MessagePropertiesUtil.LOG_START_CREATE_DOCBOOK_MARSHALLER));
-            JAXBContext jaxbContext = JAXBContext.newInstance(Article.class);
+            JAXBContext jaxbContext = getInstance(Article.class);
             Marshaller marshaller = jaxbContext.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             marshaller.setSchema(JaxbUtil.getSchema(ApplicationPropertiesUtil
@@ -134,8 +151,7 @@ public final class JaxbUtil {
         try {
             LOGGER.trace(MessagePropertiesUtil
                     .getMessage(MessagePropertiesUtil.LOG_START_CREATE_KNOWHOW_UNMARSHALLER));
-            JAXBContext jaxbContext = JAXBContext
-                    .newInstance(PortabilityKnowhow.class);
+            JAXBContext jaxbContext = getInstance(PortabilityKnowhow.class);
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
             unmarshaller
                     .setSchema(JaxbUtil.getSchema(
@@ -163,8 +179,7 @@ public final class JaxbUtil {
         try {
             LOGGER.trace(MessagePropertiesUtil
                     .getMessage(MessagePropertiesUtil.LOG_START_CREATE_KNOWHOW_MARSHALLER));
-            JAXBContext jaxbContext = JAXBContext
-                    .newInstance(PortabilityKnowhow.class);
+            JAXBContext jaxbContext = getInstance(PortabilityKnowhow.class);
             Marshaller marshaller = jaxbContext.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             marshaller
@@ -238,7 +253,7 @@ public final class JaxbUtil {
             String resourcePath) throws JAXBException, SAXException,
             MalformedURLException {
 
-        JAXBContext jaxbContext = JAXBContext.newInstance(targetClass);
+    	JAXBContext jaxbContext = getInstance(targetClass);
         Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
         unmarshaller.setSchema(JaxbUtil.getSchema(resourcePath, targetClass));
         return unmarshaller;
@@ -263,7 +278,7 @@ public final class JaxbUtil {
             Class<?> targetClass, String resourcePath) throws JAXBException,
             SAXException, MalformedURLException {
         if (DOCBOOK_UNMARSHALLER == null) {
-            JAXBContext jaxbContext = JAXBContext.newInstance(targetClass);
+        	JAXBContext jaxbContext = getInstance(targetClass);
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
             unmarshaller.setSchema(JaxbUtil
                     .getSchema(resourcePath, targetClass));
@@ -292,7 +307,7 @@ public final class JaxbUtil {
             Class<?> targetClass, String resourcePath) throws JAXBException,
             SAXException, MalformedURLException {
         if (KNOWHOW_UNMARSHALLER == null) {
-            JAXBContext jaxbContext = JAXBContext.newInstance(targetClass);
+        	JAXBContext jaxbContext = getInstance(targetClass);
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
             unmarshaller.setSchema(JaxbUtil
                     .getSchema(resourcePath, targetClass));
@@ -354,7 +369,7 @@ public final class JaxbUtil {
             String resourcePath) throws JAXBException, SAXException,
             MalformedURLException {
 
-        JAXBContext jaxbContext = JAXBContext.newInstance(targetClass);
+    	JAXBContext jaxbContext = getInstance(targetClass);
         Marshaller marshaller = jaxbContext.createMarshaller();
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
 
@@ -381,7 +396,7 @@ public final class JaxbUtil {
             String resourcePath) throws JAXBException, SAXException,
             MalformedURLException {
         if (DOCBOOK_MARSHALLER == null) {
-            JAXBContext jaxbContext = JAXBContext.newInstance(targetClass);
+        	JAXBContext jaxbContext = getInstance(targetClass);
             Marshaller marshaller = jaxbContext.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             marshaller.setSchema(JaxbUtil.getSchema(resourcePath, targetClass));
@@ -410,7 +425,7 @@ public final class JaxbUtil {
             String resourcePath) throws JAXBException, SAXException,
             MalformedURLException {
         if (KNOWHOW_MARSHALLER == null) {
-            JAXBContext jaxbContext = JAXBContext.newInstance(targetClass);
+        	JAXBContext jaxbContext = getInstance(targetClass);
             Marshaller marshaller = jaxbContext.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             marshaller.setSchema(JaxbUtil.getSchema(resourcePath, targetClass));

--- a/src/tubame.knowhow/src/tubame/knowhow/plugin/ui/editor/multi/MaintenanceKnowhowMultiPageEditor.java
+++ b/src/tubame.knowhow/src/tubame/knowhow/plugin/ui/editor/multi/MaintenanceKnowhowMultiPageEditor.java
@@ -212,7 +212,7 @@ public class MaintenanceKnowhowMultiPageEditor extends FormEditor implements
         // IFile creation of know-how detail editor for editing
         IFile tempKnowhoDetailFile = createKnowhowDetailFile();
         // Refresh the DocBook template after creating a file
-        PluginUtil.refreshWorkSpace();
+        // PluginUtil.refreshWorkSpace();
         addPage(KNOWHOWDETAIL_PAGE, knowhowDetailEditor, new FileEditorInput(
                 tempKnowhoDetailFile));
         setPageText(KNOWHOWDETAIL_PAGE, ResourceUtil.knowhowDetail);
@@ -252,7 +252,9 @@ public class MaintenanceKnowhowMultiPageEditor extends FormEditor implements
             return PluginUtil.createIFile(container, knowhowDetailTempFile,
                     false);
         }
-        return PluginUtil.createIFile(container, knowhowDetailTempFile, true);
+        IFile file = PluginUtil.createIFile(container, knowhowDetailTempFile, true);
+        PluginUtil.refreshWorkSpace();
+        return file;
     }
 
     /**


### PR DESCRIPTION
ナレッジXMLのナレッジ管理エディタでの読込み速度を向上しました。
JAXBContextクラスのインスタンスを毎回生成せずに、Map管理するように変更しました。

tmp_docbook_ja.xmlが存在したら、ワークスペースのリフレッシュを実行しないように修正しました。
ダブルクリックのたびにリフレッシュすることは無くなりました。
