### PR TITLE
Change specified stylesheet name.

### DIFF
--- a/src/tubame.knowhow/resources/xsl/knowhow.xsl
+++ b/src/tubame.knowhow/resources/xsl/knowhow.xsl
@@ -7,7 +7,7 @@
 	<xsl:include href="./docbook-xsl-ns-1.78.1/html/docbook.xsl" />
 	<xsl:output method="html" encoding="UTF-8" indent="yes" />
 	<xsl:param name="admon.graphics" select="1" />
-	<xsl:param name="html.stylesheet">css/docbook.css</xsl:param>
+	<xsl:param name="html.stylesheet">css/knowhow.css</xsl:param>
 	<xsl:param name="section.autolabel" select="1" />
 	<xsl:param name="tablecolumns.extension" select="0" />
 	<xsl:param name="use.extensions" select="1" />

--- a/src/tubame.knowhow/resources/xsl/preview.xsl
+++ b/src/tubame.knowhow/resources/xsl/preview.xsl
@@ -7,7 +7,7 @@
 	<xsl:include href="./docbook-xsl-ns-1.78.1/html/docbook.xsl" />
 	<xsl:output method="html" encoding="UTF-8" indent="yes" />
 	<xsl:param name="admon.graphics" select="1" />
-	<xsl:param name="html.stylesheet">css/docbook.css</xsl:param>
+	<xsl:param name="html.stylesheet">css/knowhow.css</xsl:param>
 	<xsl:param name="section.autolabel" select="1" />
 	<xsl:param name="tablecolumns.extension" select="0" />
 	<xsl:param name="use.extensions" select="1" />


### PR DESCRIPTION
ナレッジ管理ツールのマイグレーションガイド生成用のxslで指定しているスタイルシートのファイル名を変更する。
user-knowlegdeで用意されているcssのテンプレートファイル名がknowhow.cssなので、ツールが生成するhtmlファイル名もknowhow.cssを参照するようにすべきと考えられる。