### PR TITLE
Mainte

### DIFF
--- a/src/tubame.portability/resources/properties/application.properties
+++ b/src/tubame.portability/resources/properties/application.properties
@@ -30,3 +30,5 @@ WIN_PYTHON_SEARCH_MODULE=resources/tubame-search-modules/jbmst/jbmst.exe
 WIN_PYTHON_SEARCH_MODULE_ZIP=resources/tubame-search-modules/jbmst_win.zip
 MAC_PYTHON_SEARCH_MODULE=resources/tubame-search-modules/jbmst/jbmst.app
 MAC_PYTHON_SEARCH_MODULE_ZIP=resources/tubame-search-modules/jbmst_mac.zip
+LINUX_PYTHON_SEARCH_MODULE=resources/tubame-search-modules/jbmst/jbmst.exe
+LINUX_PYTHON_SEARCH_MODULE_ZIP=resources/tubame-search-modules/jbmst/jbmst_linux.zip

--- a/src/tubame.portability/resources/properties/application_ja.properties
+++ b/src/tubame.portability/resources/properties/application_ja.properties
@@ -30,3 +30,5 @@ WIN_PYTHON_SEARCH_MODULE=resources/tubame-search-modules/jbmst/jbmst.exe
 WIN_PYTHON_SEARCH_MODULE_ZIP=resources/tubame-search-modules/jbmst_win.zip
 MAC_PYTHON_SEARCH_MODULE=resources/tubame-search-modules/jbmst/jbmst.app
 MAC_PYTHON_SEARCH_MODULE_ZIP=resources/tubame-search-modules/jbmst_mac.zip
+LINUX_PYTHON_SEARCH_MODULE=resources/tubame-search-modules/jbmst/jbmst.exe
+LINUX_PYTHON_SEARCH_MODULE_ZIP=resources/tubame-search-modules/jbmst/jbmst_linux.zip

--- a/src/tubame.portability/src/tubame/portability/Activator.java
+++ b/src/tubame.portability/src/tubame/portability/Activator.java
@@ -97,7 +97,7 @@ public class Activator extends AbstractUIPlugin {
         
         OS_NAME = System.getProperty("os.name").toLowerCase();
         if(isSupportPyPlatform() && !isExistJbmstModulePath()){
-        	//win又はmacの場合で、かつ、JbmstModuleが存在しない場合に、bin配下のjbmstを実行可能にするようために、bin配下のjbmst_{os}.zipを展開する。
+        	//win,linux又はmacの場合で、かつ、JbmstModuleが存在しない場合に、bin配下のjbmstを実行可能にするようために、bin配下のjbmst_{os}.zipを展開する。
         	String jbmstModuleZipPath = getJbmstModuleZipPath();
         	File file = new File(jbmstModuleZipPath);
         	FileUtil.unzip(file,file.getParentFile());
@@ -275,7 +275,7 @@ public class Activator extends AbstractUIPlugin {
     }
     
     public static boolean isSupportPyPlatform(){
-    	return isWindowsPlatform();
+    	return isWindowsPlatform() || isLinuxPlatform() || isMacPlatform();
     }
     
     public static String getJbmstModulePath() throws IOException{
@@ -283,6 +283,8 @@ public class Activator extends AbstractUIPlugin {
     		return PythonUtil.getWinSearchModulePath();
     	}else if (isMacPlatform()){
     		return PythonUtil.getMacSearchModulePath();
+    	}else if (isLinuxPlatform()){
+    		return PythonUtil.getLinuxSearchModulePath();
     	}
     	return null;
     }
@@ -293,6 +295,8 @@ public class Activator extends AbstractUIPlugin {
     		return PythonUtil.getWinSearchModuleZipPath();
     	}else if (isMacPlatform()){
     		return PythonUtil.getMacSearchModuleZipPath();
+    	}else if (isLinuxPlatform()){
+    		return PythonUtil.getLinuxSearchModuleZipPath();
     	}
     	return null;
     }

--- a/src/tubame.portability/src/tubame/portability/util/PythonUtil.java
+++ b/src/tubame.portability/src/tubame/portability/util/PythonUtil.java
@@ -170,6 +170,19 @@ public class PythonUtil {
         return temp;
     }
     
+    public static String getLinuxSearchModulePath() throws IOException {
+        String temp = PluginUtil.getResolvedPluginDir()
+                + ApplicationPropertyUtil.LINUX_PYTHON_SEARCH_MODULE;
+        LOGGER.info(temp);
+        return temp;
+    }
+    
+    public static String getLinuxSearchModuleZipPath() throws IOException {
+        String temp = PluginUtil.getResolvedPluginDir()
+                + ApplicationPropertyUtil.LINUX_PYTHON_SEARCH_MODULE_ZIP;
+        LOGGER.info(temp);
+        return temp;
+    }
   
     
 }

--- a/src/tubame.portability/src/tubame/portability/util/resource/ApplicationPropertyUtil.java
+++ b/src/tubame.portability/src/tubame/portability/util/resource/ApplicationPropertyUtil.java
@@ -140,6 +140,12 @@ public class ApplicationPropertyUtil extends NLS {
 	
 	public static String MAC_PYTHON_SEARCH_MODULE_ZIP;
 	
+	public static String LINUX_PYTHON_SEARCH_MODULE;
+	
+	public static String LINUX_PYTHON_SEARCH_MODULE_ZIP;
+	
+	
+	
 
     static {
         // initialize resource bundle


### PR DESCRIPTION
pluginをpythonをインストールしなくても動作するようにlinux版の検索モジュールをcentos6.5でビルドした。
動作確認は、rhel7とcentos6.5で確認済み。