### PR TITLE
Optimize .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
-*.class
-
-# Package Files #
-*.jar
-*.war
-*.ear
+# source code of main branch files #
+src/


### PR DESCRIPTION
gh-pagesブランチではsrc配下のファイル群は関係ないため、適切な.gitignoreファイル設定に修正。