### PR TITLE
検索モジュールの検索実行で検索に失敗した場合に、検索対象のファイルを取得する際に、global変数の操作で

### DIFF
--- a/src/tubame.portability/resources/tubame-search-modules/src/jbmst.py
+++ b/src/tubame.portability/resources/tubame-search-modules/src/jbmst.py
@@ -186,7 +186,10 @@ for tempRow in tempCSVLine:
             try :
                 ext_search_module.ext_search(no,priority,flag,target_list,search_str1,search_str2,input_csv_file,search_dir,chapter_no,check_Status)
             except Exception, inst:
-                errorFilePath = ext_search_module.getErrorFilePath()
+                try:
+                    errorFilePath = ext_search_module.getErrorFilePath()
+                except NameError:
+                    errorFilePath = "None"
                 error = inst
                 raise Exception, 'Failed search (line %d): %s r\n%s' % (count,input_csv_file, error)
             continue


### PR DESCRIPTION
NameErrorがスローされる場合の対応を行った。