### PR TITLE
依存性検索すると、ツール本体で利用するXMLのチェックが実行されるのを改善

### DIFF
--- a/src/tubame.wsearch/src/tubame/wsearch/Activator.java
+++ b/src/tubame.wsearch/src/tubame/wsearch/Activator.java
@@ -1221,6 +1221,10 @@ public class Activator extends AbstractUIPlugin {
         List<WSPackage> xmlsubPackages = new ArrayList<WSPackage>();
         xmlsubPackages.add(new WSPackage("xml/xml",
                 "^http://java\\.sun\\.com/.*", true));
+        xmlsubPackages.add(new WSPackage("xml/xml",
+                "^http://docbook\\.org/ns/docbook", true));
+        xmlsubPackages.add(new WSPackage("xml/xml",
+                "^http://generated\\.model\\.biz\\.knowhow\\.tubame/.*", true));
         addSrcSearchFilter(searchFilters, "xml/xml", xmlsubTargets,
                 xmlsubPackages, true, false);
 


### PR DESCRIPTION
このファイルも検索対象として検索し、移行後の環境にこれらのXMLで利用しているスキーマがないと判断されるため、
無視リストに登録されるように修正した。