### PR TITLE
レポート生成処理時の検索ターゲットのパスの取得対応が、eclipseプロジェクトをimportしてワークスペースにコピーしない場合に

### DIFF
--- a/src/tubame.portability/src/tubame/portability/plugin/wizard/ReportGenDirSelectionPage.java
+++ b/src/tubame.portability/src/tubame/portability/plugin/wizard/ReportGenDirSelectionPage.java
@@ -286,6 +286,13 @@ public class ReportGenDirSelectionPage extends AbstractJbmSelectionPage {
 		return resource.getLocation().toOSString();
 	}
 	
+	
+	public String getSearchTargetFullPath(){
+		return  this.resource.getLocation().toOSString();
+	}
+	
+	
+
 	public String getSearchTargetDirPath(){
 		return resource.getLocation().toOSString();
 	}

--- a/src/tubame.portability/src/tubame/portability/plugin/wizard/ReportGenWizard.java
+++ b/src/tubame.portability/src/tubame/portability/plugin/wizard/ReportGenWizard.java
@@ -151,8 +151,7 @@ public class ReportGenWizard extends Wizard implements INewWizard {
 			LOGGER.info(String.format(MessageUtil.LOG_INFO_PROC_START,
 					MessageUtil.LOG_INFO_PROC_NAME_REPORTGEN));
 
-			String target = PluginUtil
-					.getFileFullPath(reportGenDirSelectionPage.getTargetText());
+			String target = reportGenDirSelectionPage.getSearchTargetFullPath();
 			
 			String reportDir = reportGenDirSelectionPage.getOutputFullPath() + File.separator + "tubame-report";
 			if(new File(reportDir).exists()){


### PR DESCRIPTION
eclipseプロジェクトをimportして、かつワークスペースにコピーしない場合に、ただしく取得できていないかったので修正