### PR TITLE
Exclusion pom.xml shema for Dependence Search

### DIFF
--- a/src/tubame.knowhow/src/tubame/knowhow/plugin/logic/KnowhowManagement.java
+++ b/src/tubame.knowhow/src/tubame/knowhow/plugin/logic/KnowhowManagement.java
@@ -431,7 +431,6 @@ public final class KnowhowManagement {
 
         // create Section
         Section section = new Section();
-        section.getTitlesAndTitleabbrevsAndSubtitles().add(title);
         Para para = new Para();
         para.getContent().add(ResourceUtil.temprateDocBookStr);
         section.getItemizedlistsAndOrderedlistsAndProcedures().add(para);

--- a/src/tubame.wsearch/src/tubame/wsearch/Activator.java
+++ b/src/tubame.wsearch/src/tubame/wsearch/Activator.java
@@ -1259,6 +1259,8 @@ public class Activator extends AbstractUIPlugin {
         xmlsubPackages.add(new WSPackage("xml/xml",
                 "^http://docbook\\.org/ns/docbook", true));
         xmlsubPackages.add(new WSPackage("xml/xml",
+                "^http://maven\\.apache\\.org/.*", true));
+        xmlsubPackages.add(new WSPackage("xml/xml",
                 "^http://generated\\.model\\.biz\\.knowhow\\.tubame/.*", true));
         addSrcSearchFilter(searchFilters, "xml/xml", xmlsubTargets,
                 xmlsubPackages, true, false);

--- a/src/tubame.wsearch/src/tubame/wsearch/util/PluginUtil.java
+++ b/src/tubame.wsearch/src/tubame/wsearch/util/PluginUtil.java
@@ -135,7 +135,7 @@ public class PluginUtil {
 	}
 	
 	public static String getProjectPath(String targetFullPath) {
-		List<String> target = new ArrayList<>();
+		List<String> target = new ArrayList();
 		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
 		for (IProject project : projects) {
 			String projectPath = project.getLocation().toOSString();


### PR DESCRIPTION
依存性検索機能において、検索対象にpom.xmlが存在する場合、
pom.xmlのmavenスキーマが移行先に存在しないと出力されるので、mavenスキーマは除去するようにした
#75 