### PR TITLE
fix #128

### DIFF
--- a/src/tubame.wsearch.biz/src/main/java/tubame/wsearch/biz/process/WSearchLibraryMetaInfoGenerateProcessor.java
+++ b/src/tubame.wsearch.biz/src/main/java/tubame/wsearch/biz/process/WSearchLibraryMetaInfoGenerateProcessor.java
@@ -380,6 +380,7 @@ public class WSearchLibraryMetaInfoGenerateProcessor extends
                     return null;
                 }
 
+                WSearchCacheManager.getInstance().unload(CacheBase.TYPE.LIBRARY);
                 for (LibraryModel library : libraries) {
                     WSearchLibraryCacheArgument argument = new WSearchLibraryCacheArgument(
                             CacheBase.TYPE.LIBRARY,


### PR DESCRIPTION
When searching, it is a problem that the cached destination library
information remains in the previous search processing